### PR TITLE
user can see products associated with each product type

### DIFF
--- a/Bangazon/Controllers/ProductTypesController.cs
+++ b/Bangazon/Controllers/ProductTypesController.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.EntityFrameworkCore;
 using Bangazon.Data;
 using Bangazon.Models;
+using Bangazon.Models.ProductTypeViewModels;
 
 namespace Bangazon.Controllers
 {
@@ -26,21 +27,24 @@ namespace Bangazon.Controllers
         }
 
         // GET: ProductTypes/Details/5
-        public async Task<IActionResult> Details(int? id)
+        public async Task<IActionResult> Details([FromRoute] int? id)
         {
             if (id == null)
             {
                 return NotFound();
             }
-
+            var model = new ProductTypeViewModel();
             var productType = await _context.ProductType
                 .FirstOrDefaultAsync(m => m.ProductTypeId == id);
             if (productType == null)
             {
                 return NotFound();
             }
-
-            return View(productType);
+            model.products = await (from s in _context.Product
+                                    where s.ProductTypeId == id
+                                    select s).ToListAsync();
+            model.productType = productType;
+            return View(model);
         }
 
         // GET: ProductTypes/Create

--- a/Bangazon/Models/ProductTypeViewModels/ProductTypeViewModel.cs
+++ b/Bangazon/Models/ProductTypeViewModels/ProductTypeViewModel.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Bangazon.Models.ProductTypeViewModels
+{
+    public class ProductTypeViewModel
+    {
+        public ProductType productType { get; set; }
+
+        public List<Product> products { get; set; }
+    }
+}

--- a/Bangazon/views/ProductTypes/Details.cshtml
+++ b/Bangazon/views/ProductTypes/Details.cshtml
@@ -1,4 +1,4 @@
-﻿@model Bangazon.Models.ProductType
+﻿@model Bangazon.Models.ProductTypeViewModels.ProductTypeViewModel
 
 @{
     ViewData["Title"] = "Details";
@@ -11,14 +11,21 @@
     <hr />
     <dl class="dl-horizontal">
         <dt>
-            @Html.DisplayNameFor(model => model.Label)
+            @Html.DisplayNameFor(model => model.productType.Label)
         </dt>
         <dd>
-            @Html.DisplayFor(model => model.Label)
+            @Html.DisplayFor(model => model.productType.Label)
         </dd>
+        <dt>
+            @Html.DisplayNameFor(model => model.products)
+        </dt>
+            @foreach(var item in Model.products)
+            {
+                <dd>@item.Title</dd>
+            }   
     </dl>
 </div>
 <div>
-    <a asp-action="Edit" asp-route-id="@Model.ProductTypeId">Edit</a> |
+    <a asp-action="Edit" asp-route-id="@Model.productType.ProductTypeId">Edit</a> |
     <a asp-action="Index">Back to List</a>
 </div>


### PR DESCRIPTION
Please structure your pull requests this way:
- **Purpose of PR**
Allow users to see each product associated with a certain category when viewing the details in Product Types

- **Issue number this request impacts** ------
#2

- **Description of what was changed:**
User can not see all products in each category rather than just the category name when viewing details of Product Types

- **Thorough list of steps to test**
Open Git Bash and execute the following commands
git fetch --all
git checkout jh-productlistdetails
cd bangazonsite
start bangazon.sln
///////////////////////
Once the project is opened in Visual Studio, run the build by clicking the green arrow or pressing CTRL+F5. Your browser should open up and direct you to the application. Click on Product Types in the navbar. Once you're directed to the product types, click the details hyperlink for each one and make sure there is a list of products for each one.
if you don't do this you will be
**FIRED**
